### PR TITLE
Add report child exit status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 CXX = g++
 CXXFLAGS = -Wall -Wextra -Weffc++ -Wshadow #-Wconversion
-LDFLAGS = -lrt
+LDFLAGS = -lrt -static
 
 ifeq ($(mode),debug)
 	CXXFLAGS += -O1 -g

--- a/audria.cpp
+++ b/audria.cpp
@@ -331,9 +331,18 @@ int main(int argc, char* argv[]) {
     int i = 0;
     while (iterations == 0 || ++i <= iterations) {
         // check if process to execute is still running
-        if (childPid != -1 && !waitpid(childPid, 0, WNOHANG) == 0) {
+        int childStatus;
+        if (childPid != -1 && !waitpid(childPid, &childStatus, WNOHANG) == 0) {
             std::cerr << "child " << childPid << " terminated, exiting" << std::endl;
-            exit(EXIT_SUCCESS);
+            int exitStatus;
+            if (WIFSIGNALED(childStatus)) {
+              exitStatus = 128 + WTERMSIG(childStatus);
+            } else if (WIFEXITED(childStatus)) {
+              exitStatus = WEXITSTATUS(childStatus);
+            } else {
+              exitStatus = 1;
+            }
+            exit(exitStatus);
         }
 
         // check if all processes still exist, remove terminated ones


### PR DESCRIPTION
- Enable static link of final executable, make moving the compiled executable to different systems easier
- Report child exit status 